### PR TITLE
Fix bug that does not reset all recipes page after search

### DIFF
--- a/src/classes/RecipeRepository.js
+++ b/src/classes/RecipeRepository.js
@@ -1,6 +1,7 @@
 export class RecipeRepository {
   constructor(recipes) {
     this.recipes = recipes;
+    this.filteredRecipes;
   }
 
 getRecipeByTag(tagName) {
@@ -36,6 +37,11 @@ getRecipesBySearch(input) {
   })
   this.recipes = recipesByName
 }
+
+  getAllRecipes(recipes) {
+    this.recipes = recipes;
+  }
+
 }
 
 

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -24,6 +24,7 @@ let currentRecipe;
 let ingredients;
 let usersData;
 let randomUser
+let recipeDataClasses
 
 const promise = Promise.all([data.recipes, data.ingredients, data.users]).then(results => {
    ingredients = results[1].ingredientsData;
@@ -97,6 +98,7 @@ shoppingTab.addEventListener('click', function() {
 })
 
 allRecipesTab.addEventListener('click', function(){
+  newRecipeRepository.getAllRecipes(recipeDataClasses)
   hideElement(mainPage)
   hideElement(myRecipes)
   hideElement(recipeCardPage)


### PR DESCRIPTION
#### What's this PR do?
- Fixes bug that keeps search results on all recipes page after leaving search results page

#### Where should the reviewer start?
- scripts.js

#### How should this be manually tested?
- Run a search and leave the all recipes page, navigate back to all recipes, and determine if all recipes are displayed
